### PR TITLE
Make users in charge of Picklers in scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Then define what actions we're able to perform on `Subscription`
 
 ```scala
 import aecor.macros.boopickleWireProtocol
+import boopickle.Default._
 
 @boopickleWireProtocol
 trait Subscription[F[_]] {

--- a/modules/boopickle-wire-protocol/src/main/scala/aecor/macros/boopickleWireProtocol.scala
+++ b/modules/boopickle-wire-protocol/src/main/scala/aecor/macros/boopickleWireProtocol.scala
@@ -95,23 +95,21 @@ object BoopickleWireProtocolMacro {
       }
             }
 
-            import _root_.boopickle.Default._
-
             final val encoder = new ${Ctor.Name(typeName.value)}[..$abstractTypes, aecor.encoding.WireProtocol.Encoded] {
               ..${
         traitStats.map {
           case q"def $name[..$tps](..$params): ${someF: Type.Name}[$out]" if someF.value == theF.value =>
             q"""
                         final def $name[..$tps](..$params): aecor.encoding.WireProtocol.Encoded[$out] = (
-                          Pickle.intoBytes((${Lit.String(name.value)}, ..${params.map(_.name.value).map(Term.Name(_))})),
-                          _root_.aecor.encoding.WireProtocol.Decoder.fromTry(bs => _root_.scala.util.Try(Unpickle[$out].fromBytes(bs)))
+                          _root_.boopickle.Default.Pickle.intoBytes((${Lit.String(name.value)}, ..${params.map(_.name.value).map(Term.Name(_))})),
+                          _root_.aecor.encoding.WireProtocol.Decoder.fromTry(bs => _root_.scala.util.Try(_root_.boopickle.Default.Unpickle[$out].fromBytes(bs)))
                         )
                       """
           case q"def $name: ${someF: Type.Name}[$out]" if someF.value == theF.value =>
             q"""
                         final val ${Pat.Var.Term(name)}: aecor.encoding.WireProtocol.Encoded[$out] = (
-                          Pickle.intoBytes(${Lit.String(name.value)}),
-                          aecor.encoding.WireProtocol.Decoder.fromTry(bs => _root_.scala.util.Try(Unpickle[$out].fromBytes(bs)))
+                          _root_.boopickle.Default.Pickle.intoBytes(${Lit.String(name.value)}),
+                          _root_.aecor.encoding.WireProtocol.Decoder.fromTry(bs => _root_.scala.util.Try(_root_.boopickle.Default.Unpickle[$out].fromBytes(bs)))
                         )
                       """
           case other =>
@@ -143,7 +141,7 @@ object BoopickleWireProtocolMacro {
                       s"$$name$$args"
                     }
                   }
-                  aecor.data.PairE(invocation, aecor.encoding.WireProtocol.Encoder.instance[$out](Pickle.intoBytes))
+                  aecor.data.PairE(invocation, aecor.encoding.WireProtocol.Encoder.instance[$out](_root_.boopickle.Default.Pickle.intoBytes))
              """
           case q"def $name: ${someF: Type.Name}[$out]" if someF.value == theF.value =>
             val nameLit =  Lit.String(name.value)
@@ -152,7 +150,7 @@ object BoopickleWireProtocolMacro {
                     final override def invoke[F[_]](mf: $unifiedBase[F]): F[$out] = mf.$name
                     final override def toString: String = $nameLit
                   }
-                  aecor.data.PairE(invocation, aecor.encoding.WireProtocol.Encoder.instance[$out](Pickle.intoBytes))
+                  aecor.data.PairE(invocation, aecor.encoding.WireProtocol.Encoder.instance[$out](_root_.boopickle.Default.Pickle.intoBytes))
              """
           case other =>
             abort(s"Illegal method [$other]")

--- a/modules/example/src/main/scala/aecor/example/domain/transaction/TransactionAggregate.scala
+++ b/modules/example/src/main/scala/aecor/example/domain/transaction/TransactionAggregate.scala
@@ -5,6 +5,7 @@ import aecor.example.domain.Amount
 import aecor.example.domain.account.AccountId
 import aecor.example.domain.transaction.TransactionAggregate.TransactionInfo
 import aecor.macros.boopickleWireProtocol
+import boopickle.Default._
 
 final case class TransactionId(value: String) extends AnyVal
 object TransactionId {

--- a/modules/tests/src/main/scala/aecor/tests/e2e/Counter.scala
+++ b/modules/tests/src/main/scala/aecor/tests/e2e/Counter.scala
@@ -7,6 +7,7 @@ import aecor.runtime.akkapersistence.serialization.{ PersistentDecoder, Persiste
 import aecor.tests.PersistentEncoderCirce
 import aecor.tests.e2e.CounterEvent.{ CounterDecremented, CounterIncremented }
 import io.circe.generic.auto._
+import boopickle.Default._
 
 @boopickleWireProtocol
 trait Counter[F[_]] {

--- a/modules/tests/src/main/scala/aecor/tests/e2e/notification.scala
+++ b/modules/tests/src/main/scala/aecor/tests/e2e/notification.scala
@@ -3,6 +3,7 @@ package aecor.tests.e2e
 import aecor.data.Folded.syntax._
 import aecor.data._
 import aecor.macros.boopickleWireProtocol
+import boopickle.Default._
 import aecor.tests.e2e.notification.NotificationEvent.{ NotificationCreated, NotificationSent }
 
 object notification {

--- a/modules/tests/src/test/scala/aecor/tests/BoopickleWireProtocolTest.scala
+++ b/modules/tests/src/test/scala/aecor/tests/BoopickleWireProtocolTest.scala
@@ -10,15 +10,15 @@ import cats.implicits._
 import org.scalatest.{ FunSuite, Matchers }
 import io.aecor.liberator.syntax._
 import java.util.UUID
-import GadtTest._
-
-object GadtTest {
+import BoopickleWireProtocolTest._
+import boopickle.Default._
+object BoopickleWireProtocolTest {
 
   final case class FooId(value: UUID) extends AnyVal
 
 }
 
-class GadtTest extends FunSuite with Matchers {
+class BoopickleWireProtocolTest extends FunSuite with Matchers {
 
   @boopickleWireProtocol
   trait Foo[F[_]] {


### PR DESCRIPTION
It is now required (until further workaround) to import `boopickle.Default._` to use `@boopickleWireProtocol` macro. 

Refs #40.