### PR TITLE
Bump deps and scala to 2.12.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,38 +5,39 @@ import pl.project13.scala.sbt._
 lazy val buildSettings = inThisBuild(
   Seq(
     organization := "io.aecor",
-    scalaVersion := "2.12.4"
+    scalaVersion := "2.12.7"
   )
 )
 
-lazy val akkaVersion = "2.5.15"
+lazy val akkaVersion = "2.5.18"
 lazy val akkaPersistenceCassandraVersion = "0.61"
 
 lazy val catsVersion = "1.4.0"
 lazy val catsEffectVersion = "1.0.0"
 lazy val scodecVersion = "1.10.4"
-lazy val logbackVersion = "1.1.7"
+lazy val logbackVersion = "1.2.3"
 lazy val cassandraDriverExtrasVersion = "3.1.0"
 lazy val jsr305Version = "3.0.1"
 lazy val boopickleVersion = "1.3.0"
-lazy val monocleVersion = "1.5.0-cats"
+lazy val monocleVersion = "1.5.1-cats"
 lazy val fs2Version = "1.0.0"
 lazy val log4catsVersion = "0.2.0-M1"
 
 lazy val scalaCheckVersion = "1.13.4"
 lazy val scalaTestVersion = "3.0.5"
-lazy val scalaCheckShapelessVersion = "1.1.4"
+lazy val scalaCheckShapelessVersion = "1.1.8"
 lazy val shapelessVersion = "2.3.3"
-lazy val kindProjectorVersion = "0.9.7"
+lazy val kindProjectorVersion = "0.9.9"
 lazy val scalametaVersion = "1.8.0"
 
 // Example dependencies
 
-lazy val circeVersion = "0.9.3"
-lazy val http4sVersion = "0.20.0-M1"
-lazy val scalametaParadiseVersion = "3.0.0-M10"
+lazy val circeVersion = "0.10.1"
+lazy val http4sVersion = "0.20.0-M3"
+lazy val scalametaParadiseVersion = "3.0.0-M11"
 
-lazy val catsTaglessVersion = "0.1.0"
+lazy val catsMTLVersion = "0.4.0"
+lazy val catsTaglessVersion = "0.2.0"
 
 lazy val commonSettings = Seq(
   resolvers += "jitpack" at "https://jitpack.io",
@@ -44,8 +45,16 @@ lazy val commonSettings = Seq(
   addCompilerPlugin("org.spire-math" %% "kind-projector" % kindProjectorVersion),
   parallelExecution in Test := false,
   scalacOptions in (Compile, doc) := (scalacOptions in (Compile, doc)).value
-    .filter(_ != "-Xfatal-warnings")
+    .filter(_ != "-Xfatal-warnings"),
 ) ++ warnUnusedImport
+
+lazy val macroSettings = Seq(
+  scalacOptions += "-Xplugin-require:macroparadise",
+  addCompilerPlugin(
+    "org.scalameta" % "paradise" % scalametaParadiseVersion cross CrossVersion.full
+  ),
+  sources in (Compile, doc) := Nil // macroparadise doesn't work with scaladoc yet.
+)
 
 lazy val aecorSettings = buildSettings ++ commonSettings ++ publishSettings
 
@@ -94,6 +103,7 @@ lazy val akkaGeneric =
     .dependsOn(core)
     .dependsOn(boopickleWireProtocol % "test->compile")
     .settings(aecorSettings)
+    .settings(macroSettings)
     .settings(commonTestSettings)
     .settings(akkaGenericSettings)
 
@@ -114,14 +124,7 @@ lazy val testKit = aecorModule("test-kit", "Aecor Test Kit")
   .settings(testKitSettings)
 
 lazy val tests = aecorModule("tests", "Aecor Tests")
-  .dependsOn(
-    core,
-    schedule,
-    testKit,
-    akkaPersistence,
-    distributedProcessing,
-    boopickleWireProtocol
-  )
+  .dependsOn(core, schedule, testKit, akkaPersistence, distributedProcessing, boopickleWireProtocol)
   .settings(aecorSettings)
   .settings(noPublishSettings)
   .settings(testingSettings)
@@ -150,32 +153,22 @@ lazy val coreSettings = Seq(
 )
 
 lazy val boopickleWireProtocolSettings = Seq(
-  addCompilerPlugin(
-    "org.scalameta" % "paradise" % scalametaParadiseVersion cross CrossVersion.patch
-  ),
-  sources in (Compile, doc) := Nil,
-  scalacOptions in (Compile, console) := Seq(),
   libraryDependencies ++= Seq(
     "io.suzaku" %% "boopickle" % boopickleVersion,
     "org.scalameta" %% "scalameta" % scalametaVersion
   )
-)
+) ++ macroSettings
 
 lazy val scheduleSettings = commonProtobufSettings ++ Seq(
-  sources in (Compile, doc) := Nil,
-  addCompilerPlugin(
-    "org.scalameta" % "paradise" % scalametaParadiseVersion cross CrossVersion.patch
-  ),
   libraryDependencies ++= Seq(
     "com.datastax.cassandra" % "cassandra-driver-extras" % cassandraDriverExtrasVersion,
     "com.google.code.findbugs" % "jsr305" % jsr305Version % Compile
   )
-)
+) ++ macroSettings
 
 lazy val distributedProcessingSettings = commonProtobufSettings ++ Seq(
   libraryDependencies ++= Seq("com.typesafe.akka" %% "akka-cluster-sharding" % akkaVersion)
 )
-
 
 lazy val akkaPersistenceSettings = commonProtobufSettings ++ Seq(
   libraryDependencies ++= Seq(
@@ -191,18 +184,15 @@ lazy val akkaGenericSettings = commonProtobufSettings ++ Seq(
   libraryDependencies ++= Seq("com.typesafe.akka" %% "akka-cluster-sharding" % akkaVersion)
 )
 
-lazy val exampleSettings = {
+lazy val exampleSettings =
   Seq(
-    addCompilerPlugin(
-      "org.scalameta" % "paradise" % scalametaParadiseVersion cross CrossVersion.patch
-    ),
     resolvers += Resolver.sonatypeRepo("releases"),
     resolvers += "krasserm at bintray" at "http://dl.bintray.com/krasserm/maven",
     libraryDependencies ++=
       Seq(
-        "com.github.krasserm" %% "streamz-converter" % "0.10-M1",
+        "com.github.krasserm" %% "streamz-converter" % "0.10-M2",
         "co.fs2" %% "fs2-core" % "1.0.0",
-        "org.typelevel" %% "cats-mtl-core" % "0.4.0",
+        "org.typelevel" %% "cats-mtl-core" % catsMTLVersion,
         "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,
         "org.http4s" %% "http4s-dsl" % http4sVersion,
         "org.http4s" %% "http4s-blaze-server" % http4sVersion,
@@ -213,21 +203,17 @@ lazy val exampleSettings = {
         "io.circe" %% "circe-java8" % circeVersion,
         "ch.qos.logback" % "logback-classic" % logbackVersion
       )
-  )
-}
+  ) ++ macroSettings
 
 lazy val testKitSettings = Seq(
   libraryDependencies ++= Seq(
-    "org.typelevel" %% "cats-mtl-core" % "0.4.0",
+    "org.typelevel" %% "cats-mtl-core" % catsMTLVersion,
     "com.github.julien-truffaut" %% "monocle-core" % monocleVersion,
     "com.github.julien-truffaut" %% "monocle-macro" % monocleVersion
   )
 )
 
 lazy val testingSettings = Seq(
-  addCompilerPlugin(
-    "org.scalameta" % "paradise" % scalametaParadiseVersion cross CrossVersion.patch
-  ),
   libraryDependencies ++= Seq(
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
@@ -240,13 +226,10 @@ lazy val testingSettings = Seq(
     "com.github.alexarchambault" %% "scalacheck-shapeless_1.13" % scalaCheckShapelessVersion % Test,
     "org.typelevel" %% "cats-testkit" % catsVersion % Test
   )
-)
+) ++ macroSettings
 
 lazy val commonTestSettings =
   Seq(
-    addCompilerPlugin(
-      "org.scalameta" % "paradise" % scalametaParadiseVersion cross CrossVersion.patch
-    ),
     libraryDependencies ++= Seq(
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion % Test,
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test,

--- a/modules/akka-cluster-runtime/src/test/scala/aecor/runtime/akkageneric/Counter.scala
+++ b/modules/akka-cluster-runtime/src/test/scala/aecor/runtime/akkageneric/Counter.scala
@@ -1,6 +1,6 @@
 package aecor.runtime.akkageneric
 
-import aecor.encoding.{ KeyDecoder, KeyEncoder }
+import aecor.encoding.{KeyDecoder, KeyEncoder}
 import aecor.macros.boopickleWireProtocol
 import boopickle.Default._
 import cats.effect.Sync
@@ -8,8 +8,8 @@ import cats.effect.concurrent.Ref
 import cats.implicits._
 import cats.tagless.autoFunctorK
 
+@autoFunctorK(false)
 @boopickleWireProtocol
-@autoFunctorK
 trait Counter[F[_]] {
   def increment: F[Long]
   def decrement: F[Long]

--- a/modules/tests/src/main/scala/aecor/tests/e2e/Counter.scala
+++ b/modules/tests/src/main/scala/aecor/tests/e2e/Counter.scala
@@ -14,7 +14,7 @@ import cats.tagless.autoFunctorK
 import cats.{ Eq, Monad }
 
 @boopickleWireProtocol
-@autoFunctorK
+@autoFunctorK(false)
 trait Counter[F[_]] {
   def increment: F[Long]
   def decrement: F[Long]

--- a/modules/tests/src/test/scala/aecor/tests/EndToEndTest.scala
+++ b/modules/tests/src/test/scala/aecor/tests/EndToEndTest.scala
@@ -133,7 +133,7 @@ class EndToEndTest extends FunSuite with Matchers with E2eSupport {
       _ <- second.increment
     } yield ()
 
-    val Right((state, _)) = program.value
+    val Right((state, _)) = program
       .run(
         SpecState(
           StateEventJournal.State.init,

--- a/modules/tests/src/test/scala/aecor/tests/ScheduleEventCodecSpec.scala
+++ b/modules/tests/src/test/scala/aecor/tests/ScheduleEventCodecSpec.scala
@@ -4,7 +4,7 @@ import java.time.{Instant, LocalDateTime}
 
 import aecor.runtime.akkapersistence.serialization.{PersistentDecoder, PersistentEncoder}
 import aecor.schedule.ScheduleEvent
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalatest.prop.PropertyChecks
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,14 +1,16 @@
 logLevel := Level.Warn
 
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.12")
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.2")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.9.3")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.3")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.14")
 
-libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.6"
+addSbtPlugin("com.lucidchart" % "sbt-scalafmt" % "1.15")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.19")
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.8.2"


### PR DESCRIPTION
Scalameta 1.8.0 macro annotations actually work under 2.12.7. So I managed to bump everything. My separate demo project also works fine with this.