### PR TITLE
Suppress wart warnings in BoopickleWireProtocol

### DIFF
--- a/modules/boopickle-wire-protocol/src/main/scala/aecor/macros/boopickle/BoopickleWireProtocol.scala
+++ b/modules/boopickle-wire-protocol/src/main/scala/aecor/macros/boopickle/BoopickleWireProtocol.scala
@@ -2,5 +2,6 @@ package aecor.macros.boopickle
 import aecor.encoding.WireProtocol
 
 object BoopickleWireProtocol {
+  @SuppressWarnings(Array("org.wartremover.warts.All"))
   def derive[M[_[_]]]: WireProtocol[M] = macro DeriveMacros.derive[M]
 }


### PR DESCRIPTION
Macro generated code from `BoopickleWireProtocol` results in compilation failure when using [WartRemover](https://www.wartremover.org) due to the usage of `throw` and `equals`, etc. This PR attempts to avoid it.